### PR TITLE
Bugfixing: sitemap_include_in isn't shown correct on section and category page

### DIFF
--- a/src/Rah/Sitemap.php
+++ b/src/Rah/Sitemap.php
@@ -346,9 +346,10 @@ final class Rah_Sitemap
     public function renderSectionOptions($event, $step, $void, $r): string
     {
         if ($r['name'] !== 'default') {
+            $value = empty($r['rah_sitemap_include_in'])? 0 : $r['rah_sitemap_include_in'];
             return inputLabel(
                 'rah_sitemap_include_in',
-                yesnoradio('rah_sitemap_include_in', !empty($r['rah_sitemap_include_in']), '', ''),
+                yesnoradio('rah_sitemap_include_in', $value, '', ''),
                 '',
                 'rah_sitemap_include_in'
             );

--- a/src/Rah/Sitemap.php
+++ b/src/Rah/Sitemap.php
@@ -380,9 +380,10 @@ final class Rah_Sitemap
      */
     public function renderCategoryOptions($event, $step, $void, $r): string
     {
+        $value = empty($r['rah_sitemap_include_in'])? 0 : $r['rah_sitemap_include_in'];
         return inputLabel(
             'rah_sitemap_include_in',
-            yesnoradio('rah_sitemap_include_in', !empty($r['rah_sitemap_include_in']), '', ''),
+            yesnoradio('rah_sitemap_include_in', $value, '', ''),
             '',
             'rah_sitemap_include_in'
         );

--- a/src/Rah/Sitemap.php
+++ b/src/Rah/Sitemap.php
@@ -207,7 +207,7 @@ final class Rah_Sitemap
         }
 
         if (!get_pref('rah_sitemap_expired_articles')) {
-            $sql[] = "(Expires = NULL or Expires >= now())";
+            $sql[] = "(Expires IS NULL or Expires >= now())";
         }
 
         $rs = safe_rows_start(


### PR DESCRIPTION
In the Admin panels for section and category details the value of the property "sitemap_include_in" isn't shown correctly. This is because the used PHP-Function `empty()' returns **false** when the property isn't empty and **false** is mapped to an empty string.  The function `yesnoradio()` only supports zero or one as values no empty strings.