### PR TITLE
Bugfix: Wrong operator for NULL-check

### DIFF
--- a/src/Rah/Sitemap.php
+++ b/src/Rah/Sitemap.php
@@ -207,7 +207,7 @@ final class Rah_Sitemap
         }
 
         if (!get_pref('rah_sitemap_expired_articles')) {
-            $sql[] = "(Expires = NULL or Expires >= now())";
+            $sql[] = "(Expires IS NULL or Expires >= now())";
         }
 
         $rs = safe_rows_start(


### PR DESCRIPTION
Use Operator "IS" instead of "=" to check for NULL. The clause with "=" is never true. No article URLs are added to the sitemap if preference "Include expired articles?" is set to "no". 

Seen this Bug with:
* Textpattern version: 4.7.3 (7c46d1f4c8ac79e62a7d5e54a9ddac53)
* PHP version: 7.2.24-he.0
* MySQL: 5.6.45-86.1-log (Percona Server (GPL), Release 86.1, Revision 5bc37b1) 